### PR TITLE
[Fix] Resolve Unreal 5.7 compatibility issue

### DIFF
--- a/ArcweaveDemo/Source/ArcweaveDemoEditor.Target.cs
+++ b/ArcweaveDemo/Source/ArcweaveDemoEditor.Target.cs
@@ -1,19 +1,25 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 using UnrealBuildTool;
-using System.Collections.Generic;
 
 public class ArcweaveDemoEditorTarget : TargetRules
 {
-	public ArcweaveDemoEditorTarget(TargetInfo Target) : base(Target)
-	{
-		Type = TargetType.Editor;
-		DefaultBuildSettings = BuildSettingsVersion.V2;
-		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
-		ExtraModuleNames.Add("ArcweaveDemo");
-         #if UE_5_5_OR_LATER
-             DefaultBuildSettings = BuildSettingsVersion.V5;
-             CppStandard = CppStandardVersion.Cpp20;
-         #endif
-	}
+    public ArcweaveDemoEditorTarget(TargetInfo Target) : base(Target)
+    {
+        Type = TargetType.Editor;
+        DefaultBuildSettings = BuildSettingsVersion.V2;
+        IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
+        ExtraModuleNames.Add("ArcweaveDemo");
+#if UE_5_5_OR_LATER
+        DefaultBuildSettings = BuildSettingsVersion.V5;
+        CppStandard = CppStandardVersion.Cpp20;
+        bOverrideBuildEnvironment = true;
+#endif
+
+#if UE_5_7_OR_LATER
+        DefaultBuildSettings = BuildSettingsVersion.V6;
+        bOverrideBuildEnvironment = true;
+#endif
+
+    }
 }


### PR DESCRIPTION
Introduced a change in *ArcweaveDemoEditor.Target.cs* to make it work with 5.7 and to keep retro compatibility with Unreal 5.5
since the project wasn't able to build in 5.7 infact Unreal now requires

`
        DefaultBuildSettings = BuildSettingsVersion.V6;
`



